### PR TITLE
wavelength units should be angstrom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,4 @@ target/
 doc/source/generated
 
 # Microsoft VS Code editor
-settings.json
+.vscode/

--- a/hkl/calc.py
+++ b/hkl/calc.py
@@ -13,7 +13,7 @@ from .context import UsingEngine
 
 logger = logging.getLogger(__name__)
 
-A_KEV = 12.39842 # 12.2984244   # angstrom * keV
+A_KEV = 12.39842  # 1 Angstrom = 12.39842 keV
 NM_KEV = 1.239842  # lambda = 1.24 / E (nm, keV or um, eV)
 # Note: NM_KEV is not used by hklpy now, remains here as legacy
 

--- a/hkl/calc.py
+++ b/hkl/calc.py
@@ -13,7 +13,7 @@ from .context import UsingEngine
 
 logger = logging.getLogger(__name__)
 
-A_KEV = 12.3984244   # angstrom * keV
+A_KEV = 12.39842 # 12.2984244   # angstrom * keV
 NM_KEV = 1.239842  # lambda = 1.24 / E (nm, keV or um, eV)
 # Note: NM_KEV is not used by hklpy now, remains here as legacy
 

--- a/hkl/calc.py
+++ b/hkl/calc.py
@@ -13,7 +13,9 @@ from .context import UsingEngine
 
 logger = logging.getLogger(__name__)
 
+A_KEV = 12.3984244   # angstrom * keV
 NM_KEV = 1.239842  # lambda = 1.24 / E (nm, keV or um, eV)
+# Note: NM_KEV is not used by hklpy now, remains here as legacy
 
 
 def default_decision_function(position, solutions):
@@ -133,7 +135,7 @@ class CalcRecip(object):
 
     @property
     def wavelength(self):
-        '''The wavelength associated with the geometry, in nm'''
+        '''The wavelength associated with the geometry, in angstrom'''
         return self._geometry.wavelength_get(self._units)
 
     @wavelength.setter
@@ -143,11 +145,11 @@ class CalcRecip(object):
     @property
     def energy(self):
         '''The energy associated with the geometry, in keV'''
-        return NM_KEV / self.wavelength
+        return A_KEV / self.wavelength
 
     @energy.setter
     def energy(self, energy):
-        self.wavelength = NM_KEV / energy
+        self.wavelength = A_KEV / energy
 
     @property
     def engine_locked(self):

--- a/tests/test_tardis.py
+++ b/tests/test_tardis.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env py.test
+
 import pytest
 import numpy.testing
 
@@ -5,6 +7,8 @@ import ophyd
 from ophyd import Component as Cpt
 from ophyd import (PseudoSingle, SoftPositioner)
 
+import gi
+gi.require_version('Hkl', '5.0')
 from hkl.calc import UnreachableError
 from hkl.diffract import E6C
 from hkl.util import Lattice
@@ -31,12 +35,8 @@ class Tardis(E6C):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.omega._set_position(0)
-        self.theta._set_position(0)
-        self.chi._set_position(0)
-        self.phi._set_position(0)
-        self.delta._set_position(0)
-        self.gamma._set_position(0)
+        for p in self.real_positioners:
+            p._set_position(0)  # give each a starting position
 
 
 @pytest.fixture(scope='function')
@@ -76,8 +76,7 @@ def sample(tardis):
     r2 = tardis.calc.sample.add_reflection(1, 1, 0, position=p2)
     tardis.calc.sample.compute_UB(r1, r2)
 
-    tardis.energy.put(0.931)
-    # tardis.calc.energy = 0.931
+    tardis.energy.put(0.931)        # keV  (wavelength _must_ be 1.3317...)
     print('energy is', tardis.energy.get())
     print('calc.energy is', tardis.calc.energy)
     print('calc.wavelength is', tardis.calc.wavelength)

--- a/tests/test_tardis.py
+++ b/tests/test_tardis.py
@@ -77,7 +77,9 @@ def sample(tardis):
     r2 = tardis.calc.sample.add_reflection(1, 1, 0, position=p2)
     tardis.calc.sample.compute_UB(r1, r2)
 
-    tardis.energy.put(9.31)        # keV  (wavelength _must_ be 1.3317...)
+    # note: tardis.energy.put() writes to tardis.calc.energy
+    # but: direct writes to tardis.calc.energy do NOT update tardis.energy
+    tardis.energy.put(9.31)        # keV  (wavelength _must_ be 1.3317... angstroms)
     print('energy is', tardis.energy.get())
     print('calc.energy is', tardis.calc.energy)
     print('calc.wavelength is', tardis.calc.wavelength)

--- a/tests/test_tardis.py
+++ b/tests/test_tardis.py
@@ -76,7 +76,7 @@ def sample(tardis):
     r2 = tardis.calc.sample.add_reflection(1, 1, 0, position=p2)
     tardis.calc.sample.compute_UB(r1, r2)
 
-    tardis.energy.put(0.931)        # keV  (wavelength _must_ be 1.3317...)
+    tardis.energy.put(9.31)        # keV  (wavelength _must_ be 1.3317...)
     print('energy is', tardis.energy.get())
     print('calc.energy is', tardis.calc.energy)
     print('calc.wavelength is', tardis.calc.wavelength)

--- a/tests/test_tardis.py
+++ b/tests/test_tardis.py
@@ -15,7 +15,8 @@ from hkl.util import Lattice
 
 
 def setup_module(module):
-    ophyd.setup_ophyd()
+    # ophyd.setup_ophyd()
+    pass
 
 
 class Tardis(E6C):


### PR DESCRIPTION
fixes #17

The wavelength units **must** match the same units used by the lattice parameters.  When X-ray energy is specified, the computed wavelength must be in angstrom.