### PR TITLE
CI: Build and publish docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,3 @@ script:
         pip install doctr
         doctr deploy --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master hklpy
     fi
-
-after_success:
-  - env | sort
-  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,18 @@ script:
   - |
     if [ ! -z "${BUILD_AND_PUBLISH_DOCS}" ]; then
         set -e
-        pip install -r requirements-doc.txt
+        # Install deps for building the docs.
+        pip install --upgrade -r requirements-doc.txt
+
+        # Build the docs.
         make -C doc/ html
-        pip install doctr
-        doctr deploy --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master hklpy
-    fi
+
+        # Upload the docs to gh-pages.
+
+        # doctr deploy --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master hklpy
+
+        # A fix for doctr-versions-menu:
+        pip install pyparsing --upgrade
+        DEPLOY_DIR="hklpy/${TRAVIS_TAG:=master}"
+        doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master ${DEPLOY_DIR}
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,4 @@ script:
         pip install pyparsing --upgrade
         DEPLOY_DIR="hklpy/${TRAVIS_TAG:=master}"
         doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master ${DEPLOY_DIR}
-fi
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ cache:
   directories:
     - $HOME/.cache/pip
 
-env:
-  global:
-    # Doctr deploy key for bluesky/bluesky.github.io
-    - secure: "YBcBYqB5XJZz9JIlPUHIYWJ9asnwhh+5oPCDmtJBa8XkAr+8sg0dCrtcnZUdbWh3lFwTEHVRzWcFKMK7QEYU+gxo+YuKUx1rDrBPDDYXeobup2R+XNMqnqJym7zzffr2jL18MHF+z97fgXta3DhNgTeAniasgi2jK56/XtAVCdVlvfdq+QxQGCMB/L4cQ5CNGNDhfMyhs2H5NiCPazdpMIosLbgTi0CZmTnCt/nbozA//+tC6Ppp5nDroCNGph3aA3bH4Ya05aFaK/mxc4VIXY+jpKj1ROmfA43i2zyGzPy9IEHpCvBzYNGf+MLl2iTbB33xsGh2agclZ5zaSNVJ6CbnV7YmPD0wdwe3XXeHOi+TTU420OWGp2KyriowBphTgJBKoOiwAlnUO1mm21cqFec0xCpiLSw3OwK5oBF33J1ANeBZH0KNV3xhYs+QAypqDnwY7w/sDOHvpGNV7TqRflyOUcTwqB8jDnpbAtxP5XYY8bqd5Il43LJx7Fwj1726fEAQtI9T56IYUxMAU+/kCXTHeOq3u2T01MBgYWNoCgkPf9lcFrLtyWS4gAj5DyeRnASlbEpwTi97w9OrUpwDUI4nN2zo7TrtI63JxnMYSzeZfXguNR7xC/SNYjWWT06UqnrMw76a/ir3hxFz2a4P12pSmhDLGAs9FQT3zpZFUQI="
-
 jobs:
   fast_finish: true
   include:
@@ -18,7 +13,10 @@ jobs:
     - python: 3.7
     - python: 3.8
     - python: 3.6
-      env: PUBLISH_DOCS=1
+      env:
+        - BUILD_AND_PUBLISH_DOCS=1
+        # Doctr deploy key for bluesky/bluesky.github.io
+        - secure: "YBcBYqB5XJZz9JIlPUHIYWJ9asnwhh+5oPCDmtJBa8XkAr+8sg0dCrtcnZUdbWh3lFwTEHVRzWcFKMK7QEYU+gxo+YuKUx1rDrBPDDYXeobup2R+XNMqnqJym7zzffr2jL18MHF+z97fgXta3DhNgTeAniasgi2jK56/XtAVCdVlvfdq+QxQGCMB/L4cQ5CNGNDhfMyhs2H5NiCPazdpMIosLbgTi0CZmTnCt/nbozA//+tC6Ppp5nDroCNGph3aA3bH4Ya05aFaK/mxc4VIXY+jpKj1ROmfA43i2zyGzPy9IEHpCvBzYNGf+MLl2iTbB33xsGh2agclZ5zaSNVJ6CbnV7YmPD0wdwe3XXeHOi+TTU420OWGp2KyriowBphTgJBKoOiwAlnUO1mm21cqFec0xCpiLSw3OwK5oBF33J1ANeBZH0KNV3xhYs+QAypqDnwY7w/sDOHvpGNV7TqRflyOUcTwqB8jDnpbAtxP5XYY8bqd5Il43LJx7Fwj1726fEAQtI9T56IYUxMAU+/kCXTHeOq3u2T01MBgYWNoCgkPf9lcFrLtyWS4gAj5DyeRnASlbEpwTi97w9OrUpwDUI4nN2zo7TrtI63JxnMYSzeZfXguNR7xC/SNYjWWT06UqnrMw76a/ir3hxFz2a4P12pSmhDLGAs9FQT3zpZFUQI="
 
 install:
   # Install conda.
@@ -57,10 +55,11 @@ script:
   - conda deactivate
   - conda activate $CONDA_ENV
   - py.test -vv --cov=hkl --cov-report term-missing hkl/tests
-  - set -e
-  - make -C doc html
   - |
-    if [ ! -z "${PUBLISH_DOCS}" ]; then
+    if [ ! -z "${BUILD_AND_PUBLISH_DOCS}" ]; then
+      - set -e
+      - pip install -r requirements-doc.txt
+      - make -C doc html
       - pip install doctr
       - doctr deploy --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master hklpy
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,11 @@ script:
   - py.test -vv --cov=hkl --cov-report term-missing hkl/tests
   - |
     if [ ! -z "${BUILD_AND_PUBLISH_DOCS}" ]; then
-      - set -e
-      - pip install -r requirements-doc.txt
-      - make -C doc html
-      - pip install doctr
-      - doctr deploy --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master hklpy
+        set -e
+        pip install -r requirements-doc.txt
+        make -C doc/ html
+        pip install doctr
+        doctr deploy --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master hklpy
     fi
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Circle CI](https://circleci.com/gh/NSLS-II/hklpy.svg?style=svg)](https://circleci.com/gh/NSLS-II/hklpy)
-
-[![Code Health](https://landscape.io/github/NSLS-II/hklpy/master/landscape.svg?style=flat)](https://landscape.io/github/NSLS-II/hklpy/master)
+[![Build Status](https://travis-ci.org/bluesky/hklpy.svg?branch=main)](https://travis-ci.org/bluesky/hklpy)
+[![Code Health](https://landscape.io/github/bluesky/hklpy/main/landscape.svg?style=flat)](https://landscape.io/github/bluesky/hklpy/main)
 
 hklpy
 =====
@@ -22,6 +21,8 @@ from hkl.diffract import E4CV
 **NOTE**: main repository: https://repo.or.cz/hkl.git (GitHub repo
 https://github.com/picca/hkl is a shadow copy that may not be
 synchronized with the latest version from repo.or.cz)
+
+**NOTE**: hklpy documentation: https://blueskyproject.io/hklpy
 
 **NOTE**: Bluesky framework documentation: https://blueskyproject.io
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,3 +1,5 @@
+doctr
+doctr-versions-menu
 ipython
 matplotlib
 numpydoc

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,6 @@
+ipython
+matplotlib
+numpydoc
+sphinx
+sphinx-copybutton
+sphinx_rtd_theme


### PR DESCRIPTION
The versioned documentation is based on https://github.com/caproto/caproto/blob/21737c75659bbade2127faa541f954d0ea961a14/.travis.yml#L109-L112, thanks to @klauer for figuring it out.

Fixes #31.