### PR TITLE
CI/DOC: Use main branch if no tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,6 @@ script:
 
         # A fix for doctr-versions-menu:
         pip install pyparsing --upgrade
-        DEPLOY_DIR="hklpy/${TRAVIS_TAG:=master}"
+        DEPLOY_DIR="hklpy/${TRAVIS_TAG:=main}"
         doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master ${DEPLOY_DIR}
     fi


### PR DESCRIPTION
This is a small follow up on #35, to match the default branch of this repo with the directory structure in https://github.com/bluesky/bluesky.github.io.

Please note, the documentation is available at https://blueskyproject.io/hklpy/master/. I tried to manually fix the redirection from https://blueskyproject.io/hklpy/ via https://github.com/bluesky/bluesky.github.io/commit/685200a75224df7cfeaf6c884eb251109609fd94, but it did not seem to help unless I type https://blueskyproject.io/hklpy/index.html. Any ideas?