### PR TITLE
CI/DOC: do not overwrite index.html in bluesky/bluesky.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,13 @@ script:
 
         # A fix for doctr-versions-menu:
         pip install pyparsing --upgrade
+
         DEPLOY_DIR="hklpy/${TRAVIS_TAG:=main}"
+
+        # Avoid updating /index.html in the bluesky/bluesky.github.io repo.
+        # See https://goerz.github.io/doctr_versions_menu/v0.3.0/command.html#customizing-index-html
+        # for details.
+        export DOCTR_VERSIONS_MENU_WRITE_INDEX_HTML=false
+
         doctr deploy --command=doctr-versions-menu --build-tags --deploy-repo bluesky/bluesky.github.io --deploy-branch-name master ${DEPLOY_DIR}
     fi


### PR DESCRIPTION
Context: https://github.com/bluesky/hklpy/pull/36#issuecomment-700314184.

This is resolved via the environment variable `DOCTR_VERSIONS_MENU_WRITE_INDEX_HTML=false` (see https://goerz.github.io/doctr_versions_menu/v0.3.0/command.html#customizing-index-html for details). I tested the generation of the docs branch locally, and with this setting the `index.html` is not updated.

attn @klauer @danielballan @prjemian 