### PR TITLE
add energy features to Diffractometer base class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ doc/source/generated
 
 # Microsoft VS Code editor
 .vscode/
+.history/

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -105,6 +105,29 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 
+# -- Options for autodoc ---------------------------------------------------
+
+autodoc_exclude_members = ",".join("""
+  __weakref__
+  _component_kinds
+  _device_tuple
+  _required_for_connection
+  _sig_attrs
+  _sub_devices
+  calc_class
+  component_names
+""".split())
+autodoc_default_options = {
+    #'members': 'var1, var2',
+    #'member-order': 'bysource',
+    'private-members': True,
+    'special-members': '__init__',
+    # 'undoc-members': True,
+    'exclude-members': autodoc_exclude_members,
+}
+autodoc_mock_imports = [
+  "pint",
+]
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/doc/source/diffract.rst
+++ b/doc/source/diffract.rst
@@ -53,7 +53,7 @@ Source code documentation
 
 ----
 
-_diffract.examples:
+.. _diffract.examples:
 
 Examples
 ++++++++
@@ -190,16 +190,21 @@ of the diffractometer's *calc* engine. We expect this to be either 1
 
 We'll also create a (non-EPICS) signal to provide for an energy offset
 (in the same units as the control system energy). This offset will be
-*added* to the control system energy, before conversion of the units to
-*keV* and then setting the diffractometer's *calc* engine energy (which
-then sets the wavelength)::
+*added* to the control system energy (in
+:meth:`~hkl.diffract.Diffractometer._update_calc_energy()`), before
+conversion of the units to *keV* and then setting the diffractometer's
+*calc* engine energy:
 
-    calc engine *energy* (keV) = control system *energy* + *offset*
+  calc engine *energy* (keV) = control system *energy* + *offset*
 
-and account for the units of the control system *energy*.  To combine
-all this, we define a new python class starting with `KappaK4CV` from
-above, adding the energy signals.  Create the custom kappa 4-circle
-subclass with energy:
+which then sets the wavelength:
+
+  calc engine *wavelength* (angstrom) = :math:`h\nu` / calc engine *energy*
+
+(:math:`h\nu=` 12.39842 angstrom :math:`\cdot` keV) and account for the
+units of the control system *energy*.  To combine all this, we define a
+new python class starting similar to `KappaK4CV` above, and adding the
+energy signals.  Create the custom kappa 4-circle subclass with energy:
 
 .. code-block:: python
     :linenos:
@@ -228,36 +233,11 @@ subclass with energy:
         tth = Component(EpicsMotor, "sky:m4")
 
         energy = Component(EpicsSignal, "optics:energy")
-        energy_EGU = Component(EpicsSignal, "optics:energy.EGU")
-        energy_update_calc = Component(
+        energy_units = Component(EpicsSignal, "optics:energy.EGU")
+        energy_offset = Component(Signal, value=0)
+        energy_update_calc_flag = Component(
             EpicsSignal,
             "optics:energy_locked")
-        energy_offset = Component(Signal, value=0)
-
-        def _energy_changed(self, value=None, **kwargs):
-            '''
-            Callback indicating that the energy signal was updated
-            '''
-            if not self.connected:
-                logger.warning(
-                    "%s not fully connected, %s.calc.energy not updated",
-                    self.name, self.name)
-                return
-            if self.energy_update_calc.get() in (1, "Yes", "locked", "OK"):
-                # energy_offset has same units as energy
-                local_energy = value + self.energy_offset.get()
-
-                # either get units from control system
-                units = self.energy_EGU.get()
-                # or define as a constant here
-                # units = "eV"
-
-                keV = pint.Quantity(local_energy, units).to("keV")
-                logger.debug(
-                    "setting %s.calc.energy = %f (keV)",
-                    self.name, keV.magnitude)
-                self._calc.energy = keV.magnitude
-                self._update_position()
 
 Create an instance of this diffractometer with::
 
@@ -265,13 +245,13 @@ Create an instance of this diffractometer with::
 
 .. note::
 
-    This command will print a log message to the console::
+    If you get a log message such as this on the console::
 
         W Fri-09:12:16 - k4cve not fully connected, k4cve.calc.energy not updated
 
-    which is expected since the update cannot happen until all EPICS
-    PVs are connected.  This code, will create the object, wait for
-    all PVs to connect, then update the `calc` engine::
+    this informs you the update cannot happen until all EPICS
+    PVs are connected.  The following code, will create the object, wait
+    for all PVs to connect, then update the `calc` engine::
 
         k4cve = KappaK4CV_Energy('', name='k4cve')
         k4cve.wait_for_connection()
@@ -288,74 +268,24 @@ when the energy signal is next updated.  To force an update to the calc
 engine, call ``_energy_changed()`` directly with the energy value as the
 argument::
 
-    k4cve._energy_changed(k4cve.energy.get())
+    k4cve._energy_changed()
 
 But this only works when the ``optics:energy_locked`` PV is 1 (permitted
 to update the calc engine energy). To update the diffractometer's *calc*
-engine energy and bypass the ``k4cve.energy_update_calc`` signal, we can
-call these routines on the command console::
+engine energy and bypass the ``k4cve.energy_update_calc_flag`` signal,
+call this command::
 
-    %mov diffractometer.energy_update_calc 1
-    diffractometer._energy_changed(diffractometer.energy.get())
-    %mov diffractometer.energy_update_calc 0
-
-or we need to modify the ``_energy_changed()`` method and provide an
-additional method that does not check this signal.  We'll move code into
-the new method and modify ``_energy_changed()`` to call it:
-
-.. code-block:: python
-    :linenos:
-
-        def _energy_changed(self, value=None, **kwargs):
-            '''
-            Callback indicating that the energy signal was updated
-            '''
-            if not self.connected:
-                logger.warning(
-                    "%s not fully connected, %s.calc.energy not updated",
-                    self.name, self.name)
-                return
-
-            if self.energy_update_calc.get() in (1, "Yes", "locked", "OK"):
-                self._update_calc_energy(value)
-
-        def _update_calc_energy(self, value=None, **kwargs):
-            '''
-            Callback indicating that the energy signal was updated
-            '''
-            if not self.connected:
-                logger.warning(
-                    "%s not fully connected, %s.calc.energy not updated",
-                    self.name, self.name)
-                return
-
-            # use either supplied value or get from signal
-            value = value or self.energy.get()
-
-            # energy_offset has same units as energy
-            local_energy = value + self.energy_offset.get()
-
-            # either get units from control system
-            units = self.energy_EGU.get()
-            # or define as a constant here
-            # units = "eV"
-
-            keV = pint.Quantity(local_energy, units).to("keV")
-            logger.debug(
-                "setting %s.calc.energy = %f (keV)",
-                self.name, keV.magnitude)
-            self._calc.energy = keV.magnitude
-            self._update_position()
+    k4cve._update_calc_energy()
 
 Finally, to set the energy of the diffractometer's *calc* engine, use
 one of these two methods:
 
-=====================================   ============================
-motive                                  command
-=====================================   ============================
-obey ``energy_update_calc`` signal      ``k4cve._energy_changed()``
-ignore ``energy_update_calc`` signal    ``k4cve._update_calc_energy()``
-=====================================   ============================
+============================   ============================
+``energy_update_calc_flag``    command
+============================   ============================
+obey signal                    ``k4cve._energy_changed()``
+ignore signal                  ``k4cve._update_calc_energy()``
+============================   ============================
 
 Each of these two methods will accept an optional ``value`` argument
 which, if provided, will be used in place of the ``energy`` signal from

--- a/doc/source/diffract.rst
+++ b/doc/source/diffract.rst
@@ -3,44 +3,45 @@
 diffract
 --------
 
-A local subclass of the desired diffractometer geometry must be created
-to define the reciprocal-space axes and customize the EPICS PVs used for
-the motor axes.  Other capabilities are also customized in a local
-subclass.
+A local subclass of :class:`hkl.diffract.Diffractometer` for the desired
+diffractometer geometry must be created to define the reciprocal-space
+axes and customize the EPICS PVs used for the motor axes.  Other
+capabilities are also customized in a local subclass.
 
 Examples are provided after the source code documentation.
 
-These are the diffractometer geometries defined:
+These are the diffractometer geometries provided by the **hkl-c++**
+library [#hklcpp]_:
 
-===========================  ==========================
-name                         description
-===========================  ==========================
-:class:`hkl.diffract.E4CH`   Eulerian 4-circle, vertical scattering plane
-:class:`hkl.diffract.E4CV`   Eulerian 4-circle, horizontal scattering plane
-:class:`hkl.diffract.E6C`    Eulerian 6-circle
-:class:`hkl.diffract.K4CV`   Kappa 4-circle, vertical scattering plane
-:class:`hkl.diffract.K6C`    Kappa 6-circle
-:class:`hkl.diffract.TwoC`   2-circle
-:class:`hkl.diffract.Zaxis`  Z-axis
-===========================  ==========================
+============================  ==========================
+name                          description
+============================  ==========================
+:class:`~hkl.diffract.E4CH`   Eulerian 4-circle, vertical scattering plane
+:class:`~hkl.diffract.E4CV`   Eulerian 4-circle, horizontal scattering plane
+:class:`~hkl.diffract.E6C`    Eulerian 6-circle
+:class:`~hkl.diffract.K4CV`   Kappa 4-circle, vertical scattering plane
+:class:`~hkl.diffract.K6C`    Kappa 6-circle
+:class:`~hkl.diffract.TwoC`   2-circle
+:class:`~hkl.diffract.Zaxis`  Z-axis
+============================  ==========================
 
 These special-use geometries are also provided by the **hkl-c++**
-library [#]_:
+library [#hklcpp]_:
 
-* :class:`hkl.diffract.Med2p3`
-* :class:`hkl.diffract.Petra3_p09_eh2`
-* :class:`hkl.diffract.SoleilMars`
-* :class:`hkl.diffract.SoleilSiriusKappa`
-* :class:`hkl.diffract.SoleilSiriusTurret`
-* :class:`hkl.diffract.SoleilSixs`
-* :class:`hkl.diffract.SoleilSixsMed1p2`
-* :class:`hkl.diffract.SoleilSixsMed2p2`
+* :class:`~hkl.diffract.Med2p3`
+* :class:`~hkl.diffract.Petra3_p09_eh2`
+* :class:`~hkl.diffract.SoleilMars`
+* :class:`~hkl.diffract.SoleilSiriusKappa`
+* :class:`~hkl.diffract.SoleilSiriusTurret`
+* :class:`~hkl.diffract.SoleilSixs`
+* :class:`~hkl.diffract.SoleilSixsMed1p2`
+* :class:`~hkl.diffract.SoleilSixsMed2p2`
 
 In all cases, see the **hkl-c++** documentation for further information
 on these geometries.
 
-.. [#] **hkl-c++** documentation:
-    https://people.debian.org/~picca/hkl/hkl.html#org7ea41dd
+.. [#hklcpp] **hkl-c++** documentation:
+    https://people.debian.org/~picca/hkl/hkl.html
 
 ----
 
@@ -346,8 +347,8 @@ the new method and modify ``_energy_changed()`` to call it:
             self._calc.energy = keV.magnitude
             self._update_position()
 
-Finally, to set the diffractometer's *calc* engine energy, use one of
-these two methods:
+Finally, to set the energy of the diffractometer's *calc* engine, use
+one of these two methods:
 
 =====================================   ============================
 motive                                  command

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: hklpy
 channels:
   - nsls2forge
+  - conda-forge
   - defaults
 dependencies:
   - python>=3.6

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - ipython
   - numpy
   - ophyd
+  - pint
   - prettytable
   - pip:
     - coveralls

--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -207,15 +207,18 @@ class Diffractometer(PseudoPositioner):
         value = value or self.energy.get()
 
         # energy_offset has same units as energy
-        local_energy = value + self.energy_offset.get()
-        units = self.energy_units.get()
+        value += self.energy_offset.get()
 
-        keV = pint.Quantity(local_energy, units).to("keV")
-        new_calc_energy = keV.magnitude
+        # comment these lines to skip unit conversion
+        units = self.energy_units.get()
+        if units != "keV":
+            keV = pint.Quantity(value, units).to("keV")
+            value = keV.magnitude
+
         logger.debug(
             "setting %s.calc.energy = %f (keV)",
-            self.name, new_calc_energy)
-        self.calc.energy = new_calc_energy
+            self.name, value)
+        self.calc.energy = value
         self._update_position()
 
     @property

--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -57,11 +57,12 @@ class Diffractometer(PseudoPositioner):
 
     .. autosummary::
 
-        ~_energy_changed
         ~calc
         ~engine
         ~forward
         ~inverse
+        ~_energy_changed
+        ~_update_calc_energy
 
     This has a corresponding calculation engine from **hklpy** that does
     forward and inverse calculations.

--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -183,12 +183,11 @@ class Diffractometer(PseudoPositioner):
             The `energy` signal is subscribed to this method
             in the :meth:`Diffractometer.__init__()` method.
         '''
-        # NOTE: enable this code when using EpicsSignal
-        # if not self.connected:
-        #     logger.warning(
-        #         "%s not fully connected, %s.calc.energy not updated",
-        #         self.name, self.name)
-        #     return
+        if not self.connected:
+            logger.warning(
+                "%s not fully connected, %s.calc.energy not updated",
+                self.name, self.name)
+            return
 
         if self._calc_energy_update_permitted:
             self._update_calc_energy(value)
@@ -197,12 +196,11 @@ class Diffractometer(PseudoPositioner):
         '''
         Callback indicating that the energy signal was updated
         '''
-        # NOTE: enable this code when using EpicsSignal
-        # if not self.connected:
-        #     logger.warning(
-        #         "%s not fully connected, %s.calc.energy not updated",
-        #         self.name, self.name)
-        #     return
+        if not self.connected:
+            logger.warning(
+                "%s not fully connected, %s.calc.energy not updated",
+                self.name, self.name)
+            return
 
         # use either supplied value or get from signal
         value = value or self.energy.get()

--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -141,7 +141,7 @@ class Diffractometer(PseudoPositioner):
 
             self._calc = self.calc_class(lock_engine=True, **calc_kw)
 
-        if not self._calc.engine_locked:
+        if not self.calc.engine_locked:
             # Reason for this is that the engine determines the pseudomotor
             # names, so if the engine is switched from underneath, the
             # pseudomotor will no longer function properly
@@ -215,7 +215,7 @@ class Diffractometer(PseudoPositioner):
         logger.debug(
             "setting %s.calc.energy = %f (keV)",
             self.name, new_calc_energy)
-        self._calc.energy = new_calc_energy
+        self.calc.energy = new_calc_energy
         self._update_position()
 
     @property
@@ -226,7 +226,7 @@ class Diffractometer(PseudoPositioner):
     @property
     def engine(self):
         '''The calculation engine associated with the diffractometer'''
-        return self._calc.engine
+        return self.calc.engine
 
     # TODO so these calculations change the internal state of the hkl
     # calculation class, which is probably not a good thing -- it becomes a
@@ -234,15 +234,15 @@ class Diffractometer(PseudoPositioner):
 
     @pseudo_position_argument
     def forward(self, pseudo):
-        solutions = self._calc.forward_iter(start=self.position, end=pseudo,
+        solutions = self.calc.forward_iter(start=self.position, end=pseudo,
                                             max_iters=100)
         logger.debug('pseudo to real: {}'.format(solutions))
         return self._decision_fcn(pseudo, solutions)
 
     @real_position_argument
     def inverse(self, real):
-        self._calc.physical_positions = real
-        return self.PseudoPosition(*self._calc.pseudo_positions)
+        self.calc.physical_positions = real
+        return self.PseudoPosition(*self.calc.pseudo_positions)
 
 
 class E4CH(Diffractometer):

--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -194,7 +194,7 @@ class Diffractometer(PseudoPositioner):
 
     def _update_calc_energy(self, value=None, **kwargs):
         '''
-        Callback indicating that the energy signal was updated
+        writes self.calc.energy from value or self.energy
         '''
         if not self.connected:
             logger.warning(

--- a/hkl/tests/test_diffract.py
+++ b/hkl/tests/test_diffract.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env py.test
+
+import pytest
+import numpy.testing
+
+from ophyd import Component as Cpt
+from ophyd import (PseudoSingle, SoftPositioner)
+
+import gi
+gi.require_version('Hkl', '5.0')
+# NOTE: MUST call gi.require_version() BEFORE import hkl
+from hkl.calc import UnreachableError, A_KEV
+from hkl.diffract import E4CV
+from hkl.util import Lattice
+
+
+class Fourc(E4CV):
+    h = Cpt(PseudoSingle, '')
+    k = Cpt(PseudoSingle, '')
+    l = Cpt(PseudoSingle, '')
+
+    omega = Cpt(SoftPositioner)
+    chi = Cpt(SoftPositioner)
+    phi = Cpt(SoftPositioner)
+    tth = Cpt(SoftPositioner)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for p in self.real_positioners:
+            p._set_position(0)  # give each a starting position
+
+
+@pytest.fixture(scope='function')
+def fourc():
+    fourc = Fourc('', name='fourc')
+    fourc.wait_for_connection()
+    fourc._update_calc_energy()
+    return fourc
+
+
+def test_calc_energy_permit(fourc):
+    assert fourc._calc_energy_update_permitted
+    fourc.energy_update_calc_flag.put(False)
+    assert not fourc._calc_energy_update_permitted
+
+    nrg = fourc.calc.energy
+    fourc.energy.put(5.989) # BTW: Cr K absorption edge
+    numpy.testing.assert_almost_equal(
+        fourc.energy.get(), 5.989)
+    numpy.testing.assert_almost_equal(
+        fourc.calc.energy, nrg)
+
+    fourc._energy_changed()
+    numpy.testing.assert_almost_equal(
+        fourc.calc.energy, nrg)
+
+    fourc._energy_changed(fourc.energy.get())
+    numpy.testing.assert_almost_equal(
+        fourc.calc.energy, nrg)
+
+    fourc._energy_changed(5.989)
+    numpy.testing.assert_almost_equal(
+        fourc.calc.energy, nrg)
+
+    fourc._update_calc_energy()
+    numpy.testing.assert_almost_equal(
+        fourc.calc.energy, 5.989)
+
+    fourc._update_calc_energy(A_KEV/1)
+    numpy.testing.assert_almost_equal(
+        fourc.calc.energy, A_KEV)
+
+
+def test_energy(fourc):
+    numpy.testing.assert_almost_equal(
+        fourc.energy.get(), fourc.calc.energy)
+
+    for nrg in (8.0, 8.04, 9.0, 0.931):
+        fourc.energy.put(nrg)
+        numpy.testing.assert_almost_equal(
+            fourc.energy.get(), nrg)
+        numpy.testing.assert_almost_equal(
+            fourc.calc.energy, nrg)
+        numpy.testing.assert_almost_equal(
+            fourc.calc.wavelength, A_KEV/nrg)
+
+
+def test_energy_offset(fourc):
+    assert fourc.energy_offset.get() == 0
+
+    nrg = 8.0
+    fourc.energy.put(nrg)
+    numpy.testing.assert_almost_equal(
+        fourc.energy.get(), nrg)
+    numpy.testing.assert_almost_equal(
+        fourc.energy.get(), fourc.calc.energy)
+
+    for offset in (0.05, -0.1):
+        fourc.energy_offset.put(offset)
+        fourc.energy.put(nrg)
+        numpy.testing.assert_almost_equal(
+            fourc.energy.get(), nrg)
+        numpy.testing.assert_almost_equal(
+            fourc.energy.get() + offset, fourc.calc.energy)
+
+def test_energy_offset_units(fourc):
+    assert fourc.energy_offset.get() == 0
+    assert fourc.energy_units.get() == "keV"
+    fourc.energy_units.put("eV")
+    assert fourc.energy_units.get() == "eV"
+
+    nrg = 931
+    fourc.energy.put(nrg)
+    numpy.testing.assert_almost_equal(
+        fourc.energy.get(), nrg)
+    numpy.testing.assert_almost_equal(
+        fourc.energy.get()/1000, fourc.calc.energy)
+
+    for offset in (5, -6):
+        fourc.energy_offset.put(offset)
+        fourc.energy.put(nrg)
+        numpy.testing.assert_almost_equal(
+            fourc.energy.get(), nrg)
+        numpy.testing.assert_almost_equal(
+            (fourc.energy.get() + offset)/1000, fourc.calc.energy)
+
+
+def test_energy_units(fourc):
+    assert fourc.energy_units.get() == "keV"
+    fourc.energy_units.put("eV")
+    assert fourc.energy_units.get() == "eV"
+
+    eV = 931
+    fourc.energy.put(eV)
+    numpy.testing.assert_almost_equal(
+        fourc.energy.get(), eV)
+    numpy.testing.assert_almost_equal(
+        fourc.calc.energy, eV/1000)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:.*imp module is deprecated in favour of importlib:DeprecationWarning


### PR DESCRIPTION
As [requested](https://github.com/bluesky/hklpy/issues/17#issuecomment-591471108), fixes #43 .

In #25, #26, and #42, an example was prepared to show how to connect *energy* from the local controls with the calc engine energy.  The additional features were:

* allow for an offset energy
* allow for conversion of energy units to the *keV* used by the calc engine
* add a flag to allow/block automatic updates of calc engine when control *energy* changes
* direct command to bypass that lock yet keep the offset and units conversion

@ambarb, @stuartcampbell, @stuwilkins, @gfabbris : Your comments and suggestions are welcome.