### PR TITLE
get all reflection details

### DIFF
--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -131,10 +131,14 @@ class Diffractometer(PseudoPositioner):
                   doc='Sample lattice')
     lattice_reciprocal = Cpt(AttributeSignal, attr='calc.sample.reciprocal',
                              doc='Reciprocal lattice')
+
     U = Cpt(AttributeSignal, attr='calc.sample.U', doc='U matrix')
     UB = Cpt(AttributeSignal, attr='calc.sample.UB', doc='UB matrix')
     reflections = Cpt(ArrayAttributeSignal, attr='calc.sample.reflections',
                       doc='Reflections')
+    reflections_details = Cpt(AttributeSignal,
+        attr='calc.sample.reflections_details',
+        doc='Details of reflections')
     ux = Cpt(AttributeSignal, attr='calc.sample.ux.value',
              doc='ux portion of the U matrix')
     uy = Cpt(AttributeSignal, attr='calc.sample.uy.value',
@@ -170,7 +174,7 @@ class Diffractometer(PseudoPositioner):
             )
 
         if configuration_attrs is None:
-            configuration_attrs = ["UB", "energy"]
+            configuration_attrs = ["UB", "energy", "reflections_details"]
 
         if decision_fcn is None:
             # the default decision function is to just grab solution #1:

--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -136,7 +136,8 @@ class Diffractometer(PseudoPositioner):
     UB = Cpt(AttributeSignal, attr='calc.sample.UB', doc='UB matrix')
     reflections = Cpt(ArrayAttributeSignal, attr='calc.sample.reflections',
                       doc='Reflections')
-    reflections_details = Cpt(AttributeSignal,
+    reflections_details = Cpt(
+        AttributeSignal,
         attr='calc.sample.reflections_details',
         doc='Details of reflections')
     ux = Cpt(AttributeSignal, attr='calc.sample.ux.value',

--- a/hkl/sample.py
+++ b/hkl/sample.py
@@ -97,6 +97,11 @@ class HklSample(object):
         except KeyError:
             raise ValueError('Invalid unit type')
 
+        # List of reflections used in computing the U & UB matrices.
+        # If UB is computed by refinement of more than two reflections,
+        # the code that sets that up will also need to manage this list.
+        self._orientation_reflections = []
+
         for name in ('lattice', 'name', 'U', 'UB', 'ux', 'uy', 'uz',
                      'reflections', ):
             value = kwargs.pop(name, None)
@@ -194,6 +199,7 @@ class HklSample(object):
 
     @U.setter
     def U(self, new_u):
+        self._orientation_reflections = []
         self._sample.U_set(util.to_hkl(new_u))
 
     def _get_parameter(self, param):
@@ -234,6 +240,7 @@ class HklSample(object):
 
     @UB.setter
     def UB(self, new_ub):
+        self._orientation_reflections = []
         self._sample.UB_set(util.to_hkl(new_ub))
 
     def _create_reflection(self, h, k, l, detector=None):
@@ -262,6 +269,7 @@ class HklSample(object):
         r2 : HklReflection
             Reflection 2
         '''
+        self._orientation_reflections = [r1, r2]
         return self._sample.compute_UB_busing_levy(r1, r2)
 
     @property
@@ -275,6 +283,7 @@ class HklSample(object):
     @reflections.setter
     def reflections(self, refls):
         self.clear_reflections()
+        self._orientation_reflections = []
         for refl in refls:
             self.add_reflection(*refl)
 
@@ -329,9 +338,9 @@ class HklSample(object):
 
     def clear_reflections(self):
         '''Clear all reflections for the current sample'''
-        reflections = self._sample.reflections_get()
-        for refl in reflections:
+        for refl in self._sample.reflections_get():
             self._sample.del_reflection(refl)
+        self._orientation_reflections = []
 
     def _refl_matrix(self, fcn):
         '''
@@ -387,20 +396,21 @@ class HklSample(object):
                                ', '.join(info))
 
     def _get_reflection_dict(self, refl):
-        """Return dictionary with detailds for the reflection."""
+        """Return dictionary with reflection details."""
         h, k, l = refl.hkl_get()
-        flag = refl.flag_get()
         geom = refl.geometry_get()
-        wavelength = geom.wavelength_get(1)
-        pos = {
-            k: v
-            for k, v in zip(geom.axis_names_get(), geom.axis_values_get(1))
-        }
         return dict(
             reflection=dict(h=h, k=k, l=l),
-            flag=flag,
-            wavelength=wavelength,
-            position=pos
+            flag=refl.flag_get(),
+            wavelength=geom.wavelength_get(1),
+            position={
+                k: v
+                for k, v in zip(
+                    geom.axis_names_get(),
+                    geom.axis_values_get(1)
+                )
+            },
+            orientation_reflection=refl in self._orientation_reflections
         )
 
     @property

--- a/hkl/sample.py
+++ b/hkl/sample.py
@@ -416,7 +416,13 @@ class HklSample(object):
     @property
     def reflections_details(self):
         """Return a list with details of all reflections."""
+        refls = self._sample.reflections_get()
+        for r in self._orientation_reflections:
+            if r not in refls:
+                # Edge case when orientation reflection was
+                # deleted from the list in libhkl.
+                refls.append(r)
         return [
             self._get_reflection_dict(r)
-            for r in self._sample.reflections_get()
+            for r in refls
         ]

--- a/hkl/sample.py
+++ b/hkl/sample.py
@@ -385,3 +385,28 @@ class HklSample(object):
         info.append('reflection_theoretical_angles={!r}'.format(self.reflection_theoretical_angles))
         return '{}({})'.format(self.__class__.__name__,
                                ', '.join(info))
+
+    def _get_reflection_dict(self, refl):
+        """Return dictionary with detailds for the reflection."""
+        h, k, l = refl.hkl_get()
+        flag = refl.flag_get()
+        geom = refl.geometry_get()
+        wavelength = geom.wavelength_get(1)
+        pos = {
+            k: v
+            for k, v in zip(geom.axis_names_get(), geom.axis_values_get(1))
+        }
+        return dict(
+            reflection=dict(h=h, k=k, l=l),
+            flag=flag,
+            wavelength=wavelength,
+            position=pos
+        )
+
+    @property
+    def reflections_details(self):
+        """Return a list with details of all reflections."""
+        return [
+            self._get_reflection_dict(r)
+            for r in self._sample.reflections_get()
+        ]

--- a/hkl/tests/test_sample.py
+++ b/hkl/tests/test_sample.py
@@ -1,4 +1,3 @@
-
 from ophyd import Component as Cpt
 from ophyd import PseudoSingle
 from ophyd import SoftPositioner
@@ -6,15 +5,16 @@ import numpy as np
 import pytest
 
 import gi
-gi.require_version('Hkl', '5.0')
+
+gi.require_version("Hkl", "5.0")
 # NOTE: MUST call gi.require_version() BEFORE import hkl
 from hkl.diffract import E4CV
 
 
 class Fourc(E4CV):
-    h = Cpt(PseudoSingle, '')
-    k = Cpt(PseudoSingle, '')
-    l = Cpt(PseudoSingle, '')
+    h = Cpt(PseudoSingle, "")
+    k = Cpt(PseudoSingle, "")
+    l = Cpt(PseudoSingle, "")
 
     omega = Cpt(SoftPositioner, limits=(-180, 180))
     chi = Cpt(SoftPositioner, limits=(-180, 180))
@@ -28,9 +28,9 @@ class Fourc(E4CV):
             p._set_position(0)  # give each a starting position
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def fourc():
-    fourc = Fourc('', name="fourc")
+    fourc = Fourc("", name="fourc")
     return fourc
 
 
@@ -46,22 +46,20 @@ def test_compute_UB(fourc):
     np.testing.assert_array_almost_equal(default_UB, sample.UB)
 
     #  compute the UB matrix from two other reflections
+    # fmt: off
     r3 = sample.add_reflection(
-        .1, .2, .3,
+        0.1, 0.2, 0.3,
         (10.7826, 32.3115, 18.4349, 21.5652)
     )
     r4 = sample.add_reflection(
-        .5, 0, .001,
+        0.5, 0, 0.001,
         (14.4775, 0, 89.8854, 28.9551)
     )
+    # fmt: on
     sample.compute_UB(r3, r4)
     # Since the angles are rounded to 4 decimal places,
     # limit the comparison as well.
-    np.testing.assert_array_almost_equal(
-        default_UB,
-        sample.UB,
-        decimal=5
-    )
+    np.testing.assert_array_almost_equal(default_UB, sample.UB, decimal=5)
 
 
 def test_orientation_reflections(fourc):
@@ -105,7 +103,7 @@ def test_orientation_reflections(fourc):
 
     sample.remove_reflection(r3)
     assert len(sample._orientation_reflections) == 2
-    sample.remove_reflection((.5, 0, .001))
+    sample.remove_reflection((0.5, 0, 0.001))
     assert len(sample._orientation_reflections) == 2
 
 
@@ -118,7 +116,7 @@ def test_reflections_details(fourc):
             # dictionary comparisons
             for key in "position reflection".split():
                 for k, v in e[key].items():
-                    assert round(abs(v-r[key][k])) == 0
+                    assert round(abs(v - r[key][k])) == 0
 
     sample = fourc.calc.sample
     assert len(sample._orientation_reflections) == 0

--- a/hkl/tests/test_sample.py
+++ b/hkl/tests/test_sample.py
@@ -1,0 +1,206 @@
+
+from bluesky import plans as bp
+from ophyd import Component as Cpt
+from ophyd import PseudoSingle
+from ophyd import SoftPositioner
+from ophyd.positioner import LimitError
+from warnings import warn
+import numpy as np
+import numpy.testing
+import pytest
+
+import gi
+gi.require_version('Hkl', '5.0')
+# NOTE: MUST call gi.require_version() BEFORE import hkl
+from hkl.diffract import E4CV
+import hkl.sample
+
+
+class Fourc(E4CV):
+    h = Cpt(PseudoSingle, '')
+    k = Cpt(PseudoSingle, '')
+    l = Cpt(PseudoSingle, '')
+
+    omega = Cpt(SoftPositioner, limits=(-180, 180))
+    chi = Cpt(SoftPositioner, limits=(-180, 180))
+    phi = Cpt(SoftPositioner, limits=(-180, 180))
+    tth = Cpt(SoftPositioner, limits=(-180, 180))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for p in self.real_positioners:
+            p._set_position(0)  # give each a starting position
+
+
+@pytest.fixture(scope='function')
+def fourc():
+    fourc = Fourc('', name="fourc")
+    return fourc
+
+
+def test_compute_UB(fourc):
+    sample = fourc.calc.sample
+    default_UB = sample.UB
+
+    fourc.calc.wavelength = 1.54
+    #  compute the UB matrix from two reflections
+    r1 = sample.add_reflection(-1, 0, 0, (30, 0, -90, 60))
+    r2 = sample.add_reflection(0, 1, 1, (45, 45, 0, 90))
+    sample.compute_UB(r1, r2)
+    np.testing.assert_array_almost_equal(default_UB, sample.UB)
+
+    #  compute the UB matrix from two other reflections
+    r3 = sample.add_reflection(
+        .1, .2, .3,
+        (10.7826, 32.3115, 18.4349, 21.5652)
+    )
+    r4 = sample.add_reflection(
+        .5, 0, .001,
+        (14.4775, 0, 89.8854, 28.9551)
+    )
+    sample.compute_UB(r3, r4)
+    # Since the angles are rounded to 4 decimal places,
+    # limit the comparison as well.
+    np.testing.assert_array_almost_equal(
+        default_UB,
+        sample.UB,
+        decimal=5
+    )
+
+
+def test_orientation_reflections(fourc):
+    sample = fourc.calc.sample
+    assert len(sample._orientation_reflections) == 0
+
+    fourc.calc.wavelength = 1.54
+    r1 = sample.add_reflection(-1, 0, 0, (30, 0, -90, 60))
+    r2 = sample.add_reflection(0, 1, 1, (45, 45, 0, 90))
+    sample.compute_UB(r1, r2)
+    assert len(sample._orientation_reflections) == 2
+    details = sample.reflections_details
+    assert details[0]["orientation_reflection"]
+    assert details[1]["orientation_reflection"]
+
+    r3 = sample.add_reflection(
+        .1, .2, .3,
+        (10.7826, 32.3115, 18.4349, 21.5652)
+    )
+    r4 = sample.add_reflection(
+        .5, 0, .001,
+        (14.4775, 0, 89.8854, 28.9551)
+    )
+    sample.compute_UB(r3, r4)
+    assert len(sample._orientation_reflections) == 2
+    details = sample.reflections_details
+    assert not details[0]["orientation_reflection"]
+    assert not details[1]["orientation_reflection"]
+    assert details[2]["orientation_reflection"]
+    assert details[3]["orientation_reflection"]
+
+    sample.compute_UB(r1, r2)
+    assert len(sample._orientation_reflections) == 2
+    details = sample.reflections_details
+    assert details[0]["orientation_reflection"]
+    assert details[1]["orientation_reflection"]
+    assert not details[2]["orientation_reflection"]
+    assert not details[3]["orientation_reflection"]
+
+    sample.remove_reflection(r3)
+    assert len(sample._orientation_reflections) == 2
+    sample.remove_reflection((.5, 0, .001))
+    assert len(sample._orientation_reflections) == 2
+
+
+def test_reflections_details(fourc):
+    def compare(expected, received):
+        for e, r in list(zip(expected, received)):
+            # scalar comparisons
+            for key in "flag orientation_reflection wavelength".split():
+                assert e[key] == r[key]
+            # dictionary comparisons
+            for key in "position reflection".split():
+                for k, v in e[key].items():
+                    assert round(abs(v-r[key][k])) == 0
+
+    sample = fourc.calc.sample
+    assert len(sample._orientation_reflections) == 0
+
+    fourc.calc.wavelength = 1.54
+    r1 = sample.add_reflection(-1, 0, 0, (30, 0, -90, 60))
+
+    details = sample.reflections_details
+    expected = [
+        dict(
+            flag=1,
+            orientation_reflection=False,
+            position=dict(chi=0, omega=30, phi=-90, tth=60),
+            reflection=dict(h=-1, k=0, l=0),
+            wavelength=1.54
+        )
+    ]
+    compare(expected, details)
+
+    r2 = sample.add_reflection(0, 1, 1, (45, 45, 0, 90))
+    expected += [
+        dict(
+            flag=1,
+            orientation_reflection=False,
+            position=dict(chi=45, omega=45, phi=0, tth=90),
+            reflection=dict(h=0, k=1, l=1),
+            wavelength=1.54
+        )
+    ]
+    r3 = sample.add_reflection(
+        .1, .2, .3,
+        (10.7826, 32.3115, 18.4349, 21.5652)
+    )
+    expected += [
+        dict(
+            flag=1,
+            orientation_reflection=False,
+            position=dict(
+                chi=32.3115,
+                omega=10.7826,
+                phi=18.4349,
+                tth=21.5652
+            ),
+            reflection=dict(h=.1, k=.2, l=.3),
+            wavelength=1.54
+        )
+    ]
+    r4 = sample.add_reflection(
+        .5, 0, .001,
+        (14.4775, 0, 89.8854, 28.9551)
+    )
+    expected += [
+        dict(
+            flag=1,
+            orientation_reflection=False,
+            position=dict(
+                chi=0,
+                omega=14.4775,
+                phi=89.8854,
+                tth=28.9551
+            ),
+            reflection=dict(h=.5, k=0, l=1e-3),
+            wavelength=1.54
+        ),
+    ]
+    details = sample.reflections_details
+    compare(expected, details)
+
+    sample.compute_UB(r1, r2)
+    expected[0]["orientation_reflection"] = True
+    expected[1]["orientation_reflection"] = True
+
+    details = sample.reflections_details
+    compare(expected, details)
+
+    sample.UB = [[1,0,0],[0,1,0],[0,0,1]]
+    assert len(sample._orientation_reflections) == 0
+    expected[0]["orientation_reflection"] = False
+    expected[1]["orientation_reflection"] = False
+
+    details = sample.reflections_details
+    compare(expected, details)

--- a/hkl/tests/test_sample.py
+++ b/hkl/tests/test_sample.py
@@ -1,19 +1,14 @@
 
-from bluesky import plans as bp
 from ophyd import Component as Cpt
 from ophyd import PseudoSingle
 from ophyd import SoftPositioner
-from ophyd.positioner import LimitError
-from warnings import warn
 import numpy as np
-import numpy.testing
 import pytest
 
 import gi
 gi.require_version('Hkl', '5.0')
 # NOTE: MUST call gi.require_version() BEFORE import hkl
 from hkl.diffract import E4CV
-import hkl.sample
 
 
 class Fourc(E4CV):
@@ -151,7 +146,7 @@ def test_reflections_details(fourc):
             wavelength=1.54
         )
     ]
-    r3 = sample.add_reflection(
+    sample.add_reflection(
         .1, .2, .3,
         (10.7826, 32.3115, 18.4349, 21.5652)
     )
@@ -169,7 +164,7 @@ def test_reflections_details(fourc):
             wavelength=1.54
         )
     ]
-    r4 = sample.add_reflection(
+    sample.add_reflection(
         .5, 0, .001,
         (14.4775, 0, 89.8854, 28.9551)
     )
@@ -197,7 +192,7 @@ def test_reflections_details(fourc):
     details = sample.reflections_details
     compare(expected, details)
 
-    sample.UB = [[1,0,0],[0,1,0],[0,0,1]]
+    sample.UB = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     assert len(sample._orientation_reflections) == 0
     expected[0]["orientation_reflection"] = False
     expected[1]["orientation_reflection"] = False

--- a/hkl/tests/test_sample.py
+++ b/hkl/tests/test_sample.py
@@ -77,6 +77,7 @@ def test_orientation_reflections(fourc):
     assert details[0]["orientation_reflection"]
     assert details[1]["orientation_reflection"]
 
+    # fmt: off
     r3 = sample.add_reflection(
         .1, .2, .3,
         (10.7826, 32.3115, 18.4349, 21.5652)
@@ -85,6 +86,7 @@ def test_orientation_reflections(fourc):
         .5, 0, .001,
         (14.4775, 0, 89.8854, 28.9551)
     )
+    # fmt: on
     sample.compute_UB(r3, r4)
     assert len(sample._orientation_reflections) == 2
     details = sample.reflections_details
@@ -125,23 +127,26 @@ def test_reflections_details(fourc):
     r1 = sample.add_reflection(-1, 0, 0, (30, 0, -90, 60))
 
     details = sample.reflections_details
+    # fmt: off
     expected = [
         dict(
             flag=1,
             orientation_reflection=False,
-            position=dict(chi=0, omega=30, phi=-90, tth=60),
+            position=dict(omega=30, chi=0, phi=-90, tth=60),
             reflection=dict(h=-1, k=0, l=0),
             wavelength=1.54
         )
     ]
+    # fmt: on
     compare(expected, details)
 
     r2 = sample.add_reflection(0, 1, 1, (45, 45, 0, 90))
+    # fmt: off
     expected += [
         dict(
             flag=1,
             orientation_reflection=False,
-            position=dict(chi=45, omega=45, phi=0, tth=90),
+            position=dict(omega=45, chi=45, phi=0, tth=90),
             reflection=dict(h=0, k=1, l=1),
             wavelength=1.54
         )
@@ -155,8 +160,8 @@ def test_reflections_details(fourc):
             flag=1,
             orientation_reflection=False,
             position=dict(
-                chi=32.3115,
                 omega=10.7826,
+                chi=32.3115,
                 phi=18.4349,
                 tth=21.5652
             ),
@@ -173,8 +178,8 @@ def test_reflections_details(fourc):
             flag=1,
             orientation_reflection=False,
             position=dict(
-                chi=0,
                 omega=14.4775,
+                chi=0,
                 phi=89.8854,
                 tth=28.9551
             ),
@@ -182,6 +187,7 @@ def test_reflections_details(fourc):
             wavelength=1.54
         ),
     ]
+    # fmt: on
     details = sample.reflections_details
     compare(expected, details)
 


### PR DESCRIPTION
Fix #75: Get the full details for each of the orientation reflections so that it will be added to the descriptors during a Bluesky run, in support of #50.  This is a code enhancement that does not modify any existing handling of reflections.  It reaches into *libhkl* for the details and makes a dictionary that is mapped to a Signal in the Diffractometer class.

Here's an example using a E4CV (fourc) diffractometer:

<details>

```python
In [1]: from hkl.util import Lattice
   ...: 
   ...: # add the sample to the calculation engine
   ...: a0 = 5.431
   ...: fourc.calc.new_sample(
   ...:     "silicon",
   ...:     lattice=Lattice(a=a0, b=a0, c=a0, alpha=90, beta=90, gamma=90)
   ...:     )
   ...: 
Out[1]: 
HklSample(name='silicon', lattice=LatticeTuple(a=5.431, b=5.431, c=5.431, alpha=90.0, beta=90.0, gamma=90.0), ux=Parameter(name='None (internally: ux)', limits=(min=-180.0, max=180.0), value=0.0, fit=True, inverted=False, units='Degree'), uy=Parameter(name='None (internally: uy)', limits=(min=-180.0, max=180.0), value=0.0, fit=True, inverted=False, units='Degree'), uz=Parameter(name='None (internally: uz)', limits=(min=-180.0, max=180.0), value=0.0, fit=True, inverted=False, units='Degree'), U=array([[1., 0., 0.],
       [0., 1., 0.],
       [0., 0., 1.]]), UB=array([[ 1.15691131e+00, -7.08403864e-17, -7.08403864e-17],
       [ 0.00000000e+00,  1.15691131e+00, -7.08403864e-17],
       [ 0.00000000e+00,  0.00000000e+00,  1.15691131e+00]]), reflections=[])

In [2]: r1 = fourc.calc.sample.add_reflection(
   ...:     4, 0, 0,
   ...:     position=fourc.calc.Position(
   ...:         tth=69.0966,
   ...:         omega=-145.451,
   ...:         chi=0,
   ...:         phi=0,
   ...:     )
   ...: )
   ...: 

In [3]: r2 = fourc.calc.sample.add_reflection(
   ...:     0, 4, 0,
   ...:     position=fourc.calc.Position(
   ...:         tth=69.0966,
   ...:         omega=-145.451,
   ...:         chi=90,
   ...:         phi=0,
   ...:     )
   ...: )
   ...: 

In [4]: fourc.calc.sample.compute_UB(r1, r2)
Out[4]: 1

In [5]: fourc.calc.sample.reflections_details
Out[5]: 
[{'reflection': {'h': 4.0, 'k': 0.0, 'l': 0.0},
  'flag': 1,
  'wavelength': 1.54,
  'position': {'omega': -145.451, 'chi': 0.0, 'phi': 0.0, 'tth': 69.0966}},
 {'reflection': {'h': 0.0, 'k': 4.0, 'l': 0.0},
  'flag': 1,
  'wavelength': 1.54,
  'position': {'omega': -145.451, 'chi': 90.0, 'phi': 0.0, 'tth': 69.0966}}]

In [6]: fourc.reflections_details.get()
Out[6]: 
[{'reflection': {'h': 4.0, 'k': 0.0, 'l': 0.0},
  'flag': 1,
  'wavelength': 1.54,
  'position': {'omega': -145.451, 'chi': 0.0, 'phi': 0.0, 'tth': 69.0966}},
 {'reflection': {'h': 0.0, 'k': 4.0, 'l': 0.0},
  'flag': 1,
  'wavelength': 1.54,
  'position': {'omega': -145.451, 'chi': 90.0, 'phi': 0.0, 'tth': 69.0966}}]

In [7]: RE(bp.scan([fourc], fourc.h, 4, 0, fourc.k, 0, 4, fourc.l, 4, 4, 41))


Transient Scan ID: 127     Time: 2020-12-29 22:54:57
Persistent Unique Scan ID: '1a7f0ce4-c354-4c6e-a9fe-e5c20669e753'
New stream: 'primary'
+-----------+------------+------------+------------+------------+-------------+------------+------------+------------+
|   seq_num |       time |    fourc_h |    fourc_k |    fourc_l | fourc_omega |  fourc_chi |  fourc_phi |  fourc_tth |
+-----------+------------+------------+------------+------------+-------------+------------+------------+------------+
|         1 | 22:54:57.6 |      4.000 |     -0.000 |      4.000 |     -53.324 |     -0.000 |     45.001 |   -106.647 |
|         2 | 22:54:57.9 |      3.900 |      0.100 |      4.000 |     -52.390 |      1.025 |     45.726 |   -104.781 |
|         3 | 22:54:58.0 |      3.800 |      0.200 |      4.000 |     -51.512 |      2.076 |     46.470 |   -103.025 |
|         4 | 22:54:58.1 |      3.700 |      0.300 |      4.000 |     -50.687 |      3.151 |     47.232 |   -101.375 |
|         5 | 22:54:58.1 |      3.600 |      0.400 |      4.000 |     -49.914 |      4.250 |     48.014 |    -99.828 |
|         6 | 22:54:58.1 |      3.500 |      0.500 |      4.000 |     -49.191 |      5.374 |     48.815 |    -98.382 |
|         7 | 22:54:58.1 |      3.400 |      0.600 |      4.000 |     -48.517 |      6.520 |     49.636 |    -97.034 |
|         8 | 22:54:58.2 |      3.300 |      0.700 |      4.000 |     -47.891 |      7.687 |     50.478 |    -95.782 |
|         9 | 22:54:58.2 |      3.200 |      0.800 |      4.000 |     -47.313 |      8.876 |     51.341 |    -94.625 |
|        10 | 22:54:58.2 |      3.100 |      0.900 |      4.000 |     -46.782 |     10.084 |     52.225 |    -93.563 |
|        11 | 22:54:58.3 |      3.000 |      1.000 |      4.000 |     -46.297 |     11.309 |     53.131 |    -92.594 |
|        12 | 22:54:58.3 |      2.900 |      1.100 |      4.000 |     -45.859 |     12.551 |     54.059 |    -91.718 |
|        13 | 22:54:58.4 |      2.800 |      1.200 |      4.000 |     -45.467 |     13.807 |     55.009 |    -90.935 |
|        14 | 22:54:58.4 |      2.700 |      1.300 |      4.000 |     -45.122 |     15.076 |     55.981 |    -90.244 |
|        15 | 22:54:58.4 |      2.600 |      1.400 |      4.000 |     -44.822 |     16.354 |     56.977 |    -89.645 |
|        16 | 22:54:58.5 |      2.500 |      1.500 |      4.000 |     -44.569 |     17.640 |     57.995 |    -89.138 |
|        17 | 22:54:58.5 |      2.400 |      1.600 |      4.000 |     -44.362 |     18.931 |     59.037 |    -88.723 |
|        18 | 22:54:58.5 |      2.300 |      1.700 |      4.000 |     -44.200 |     20.225 |     60.102 |    -88.401 |
|        19 | 22:54:58.6 |      2.200 |      1.800 |      4.000 |     -44.085 |     21.519 |     61.190 |    -88.170 |
|        20 | 22:54:58.6 |      2.100 |      1.900 |      4.000 |     -44.016 |     22.809 |     62.301 |    -88.032 |
|        21 | 22:54:58.6 |      2.000 |      2.000 |      4.000 |     -43.993 |     24.094 |     63.436 |    -87.986 |
|        22 | 22:54:58.7 |      1.900 |      2.100 |      4.000 |     -44.016 |     25.371 |     64.593 |    -88.032 |
|        23 | 22:54:58.7 |      1.800 |      2.200 |      4.000 |     -44.085 |     26.636 |     65.773 |    -88.170 |
|        24 | 22:54:58.8 |      1.700 |      2.300 |      4.000 |     -44.200 |     27.887 |     66.975 |    -88.401 |
|        25 | 22:54:58.8 |      1.600 |      2.400 |      4.000 |     -44.362 |     29.121 |     68.199 |    -88.723 |
|        26 | 22:54:58.9 |      1.500 |      2.500 |      4.000 |     -44.569 |     30.336 |     69.445 |    -89.138 |
|        27 | 22:54:59.0 |      1.400 |      2.600 |      4.000 |     -44.822 |     31.529 |     70.711 |    -89.645 |
|        28 | 22:54:59.0 |      1.300 |      2.700 |      4.000 |     -45.122 |     32.698 |     71.997 |    -90.244 |
|        29 | 22:54:59.1 |      1.200 |      2.800 |      4.000 |     -45.467 |     33.840 |     73.302 |    -90.935 |
|        30 | 22:54:59.2 |      1.100 |      2.900 |      4.000 |     -45.859 |     34.955 |     74.625 |    -91.718 |
|        31 | 22:54:59.2 |      1.000 |      3.000 |      4.000 |     -46.297 |     36.039 |     75.965 |    -92.594 |
|        32 | 22:54:59.3 |      0.900 |      3.100 |      4.000 |     -46.782 |     37.092 |     77.320 |    -93.563 |
|        33 | 22:54:59.3 |      0.800 |      3.200 |      4.000 |     -47.313 |     38.112 |     78.691 |    -94.625 |
|        34 | 22:54:59.3 |      0.700 |      3.300 |      4.000 |     -47.891 |     39.098 |     80.075 |    -95.782 |
|        35 | 22:54:59.4 |      0.600 |      3.400 |      4.000 |     -48.517 |     40.050 |     81.470 |    -97.034 |
|        36 | 22:54:59.4 |      0.500 |      3.500 |      4.000 |     -49.191 |     40.965 |     82.876 |    -98.382 |
|        37 | 22:54:59.5 |      0.400 |      3.600 |      4.000 |     -49.914 |     41.845 |     84.290 |    -99.828 |
|        38 | 22:54:59.5 |      0.300 |      3.700 |      4.000 |     -50.687 |     42.688 |     85.712 |   -101.375 |
|        39 | 22:54:59.6 |      0.200 |      3.800 |      4.000 |     -51.512 |     43.495 |     87.138 |   -103.025 |
|        40 | 22:54:59.6 |      0.100 |      3.900 |      4.000 |     -52.390 |     44.265 |     88.569 |   -104.781 |
|        41 | 22:54:59.6 |      0.000 |      4.000 |      4.000 |     -53.324 |     44.999 |     90.001 |   -106.647 |
+-----------+------------+------------+------------+------------+-------------+------------+------------+------------+
generator scan ['1a7f0ce4'] (scan num: 127)
Out[7]: ('1a7f0ce4-c354-4c6e-a9fe-e5c20669e753',)

In [8]: db[-1].primary.metadata["descriptors"][0]["configuration"]
Out[8]: 
{'fourc': {'data': {'fourc_energy': 8.0,
   'fourc_UB': [[-1.4134338019784194e-05,
     -1.4134338017674464e-05,
     -1.1569113066178867],
    [0.0, -1.1569113067042285, 1.4134338018800169e-05],
    [-1.1569113067042285, 1.7268358605022802e-10, 1.413433801880017e-05]],
   'fourc_reflections_details': [{'reflection': {'h': 4.0, 'k': 0.0, 'l': 0.0},
     'flag': 1,
     'wavelength': 1.54,
     'position': {'omega': -145.451, 'chi': 0.0, 'phi': 0.0, 'tth': 69.0966}},
    {'reflection': {'h': 0.0, 'k': 4.0, 'l': 0.0},
     'flag': 1,
     'wavelength': 1.54,
     'position': {'omega': -145.451,
      'chi': 90.0,
      'phi': 0.0,
      'tth': 69.0966}}]},
  'timestamps': {'fourc_energy': 1609304055.926218,
   'fourc_UB': 1609304055.9265704,
   'fourc_reflections_details': 1609304055.9266348},
  'data_keys': {'fourc_energy': {'source': 'SIM:fourc_energy',
    'dtype': 'number',
    'shape': []},
   'fourc_UB': {'source': 'PY:fourc.calc.sample.UB',
    'dtype': 'array',
    'shape': [3, 3]},
   'fourc_reflections_details': {'source': 'PY:fourc.calc.sample.reflections_details',
    'dtype': 'array',
    'shape': [2]}}}}

In [9]: 
```

</details>
