### PR TITLE
FIX #80 ensure read-only

### DIFF
--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -128,12 +128,14 @@ class Diffractometer(PseudoPositioner):
     geometry_name = Cpt(
         AttributeSignal,
         attr="calc.geometry_name",
-        doc="Diffractometer Geometry name"
+        doc="Diffractometer Geometry name",
+        write_access=False,
     )
     class_name = Cpt(
         AttributeSignal,
         attr="__class__.__name__",
-        doc="Diffractometer class name"
+        doc="Diffractometer class name",
+        write_access=False,
     )
 
     sample_name = Cpt(AttributeSignal, attr='calc.sample_name',


### PR DESCRIPTION
FIX #80

These two kwargs (from commit 3225c76) were left out from PR #94.  They ensure that the two signals (for diffractometer geometry name and subclass name) are not writable.